### PR TITLE
Minimal fix to incorrect imports discovery

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -64,10 +64,11 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
       File smithyBuild = Paths.get(root.getAbsolutePath(), file).toFile();
       if (smithyBuild.isFile()) {
         try {
-          result.merge(SmithyBuildLoader.load(smithyBuild.toPath()));
-          LspLog.println("Loaded build extensions " + result + " from " + smithyBuild.getAbsolutePath());
+          SmithyBuildExtensions local = SmithyBuildLoader.load(smithyBuild.toPath());
+          result.merge(local);
+          LspLog.println("Loaded build extensions " + local + " from " + smithyBuild.getAbsolutePath());
         } catch (Exception e) {
-          LspLog.println("Failed to load " + result + ": " + e.toString());
+          LspLog.println("Failed to load config from" + smithyBuild + ": " + e.toString());
         }
       }
     }

--- a/src/main/java/software/amazon/smithy/lsp/ext/DependencyDownloader.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/DependencyDownloader.java
@@ -71,7 +71,7 @@ public final class DependencyDownloader {
     try {
       JarFile jar = new JarFile(new File(path));
       ZipEntry manifestEntry = jar.getEntry("META-INF/smithy/manifest");
-      LspLog.println("Manifest entry in " + path + " is " + manifestEntry);
+      LspLog.println("Successfully found Smithy manifest in " + jar);
       return manifestEntry != null;
     } catch (Exception e) {
       LspLog.println("Failed to open " + path + " to check if it's a Smithy jar: " + e.toString());

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensions.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensions.java
@@ -73,6 +73,7 @@ public final class SmithyBuildExtensions implements ToSmithyBuilder<SmithyBuildE
         public Builder merge(SmithyBuildExtensions other) {
             mavenDependencies.addAll(other.mavenDependencies);
             mavenRepositories.addAll(other.mavenRepositories);
+            imports.addAll(other.imports);
 
             return this;
         }
@@ -129,7 +130,7 @@ public final class SmithyBuildExtensions implements ToSmithyBuilder<SmithyBuildE
 
     @Override
     public String toString() {
-        return "SmithyBuildExtensions(repositories=" + mavenRepositories.toString() + ",artifacts="
-                + mavenDependencies.toString() + ")";
+        return "SmithyBuildExtensions(repositories = " + mavenRepositories.toString() + ",artifacts = "
+                + mavenDependencies.toString() + ", imports = " + imports + ")";
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensionsTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensionsTest.java
@@ -76,12 +76,13 @@ public class SmithyBuildExtensionsTest {
         SmithyBuildExtensions.Builder builder = SmithyBuildExtensions.builder();
 
         SmithyBuildExtensions other = SmithyBuildExtensions.builder().mavenDependencies(Arrays.asList("hello", "world"))
-                .mavenRepositories(Arrays.asList("hi", "there")).build();
+                .mavenRepositories(Arrays.asList("hi", "there")).imports(Arrays.asList("i3", "i4")).build();
 
         SmithyBuildExtensions result = builder.mavenDependencies(Arrays.asList("d1", "d2"))
-                .mavenRepositories(Arrays.asList("r1", "r2")).merge(other).build();
+                .mavenRepositories(Arrays.asList("r1", "r2")).imports(Arrays.asList("i1", "i2")).merge(other).build();
 
         assertEquals(ImmutableList.of("d1", "d2", "hello", "world"), result.getMavenDependencies());
         assertEquals(ImmutableList.of("r1", "r2", "hi", "there"), result.getMavenRepositories());
+        assertEquals(ImmutableList.of("i1", "i2", "i3", "i4"), result.getImports());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When LSP loads, we start from an empty SmithyBuildExtensions, and with each discovered file, we merge the loaded extensions into the previous result.

If the merge logic is broken, we always start with empty config and discover all the files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
