### PR TITLE
Fixes for stale, misattributed, and incorrect diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -54,5 +54,3 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -254,10 +254,10 @@ public class SmithyTextDocumentService implements TextDocumentService {
      * @return a list of LSP diagnostics to publish
      */
     public List<PublishDiagnosticsParams> createPerFileDiagnostics(List<ValidationEvent> events, List<File> allFiles) {
-        Map<String, List<ValidationEvent>> byFile = new HashMap<String, List<ValidationEvent>>();
+        Map<File, List<ValidationEvent>> byFile = new HashMap<File, List<ValidationEvent>>();
 
         for (ValidationEvent ev : events) {
-            String file = ev.getSourceLocation().getFilename();
+            File file = new File(ev.getSourceLocation().getFilename());
             if (byFile.containsKey(file)) {
                 byFile.get(file).add(ev);
             } else {
@@ -268,15 +268,15 @@ public class SmithyTextDocumentService implements TextDocumentService {
         }
 
         allFiles.forEach(f -> {
-            if (!byFile.containsKey(f.getAbsolutePath())) {
-                byFile.put(f.getAbsolutePath(), Collections.emptyList());
+            if (!byFile.containsKey(f)) {
+                byFile.put(f, Collections.emptyList());
             }
         });
 
         List<PublishDiagnosticsParams> diagnostics = new ArrayList<PublishDiagnosticsParams>();
 
         byFile.entrySet().forEach(e -> {
-            diagnostics.add(createDiagnostics(e.getKey(),
+            diagnostics.add(createDiagnostics(e.getKey().toURI().toString(),
                     e.getValue().stream().map(ProtocolAdapter::toDiagnostic).collect(Collectors.toList())));
         });
 

--- a/src/main/java/software/amazon/smithy/lsp/ext/DependencyDownloader.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/DependencyDownloader.java
@@ -71,7 +71,7 @@ public final class DependencyDownloader {
     try {
       JarFile jar = new JarFile(new File(path));
       ZipEntry manifestEntry = jar.getEntry("META-INF/smithy/manifest");
-      LspLog.println("Successfully found Smithy manifest in " + jar);
+      LspLog.println("Successfully found Smithy manifest in " + path);
       return manifestEntry != null;
     } catch (Exception e) {
       LspLog.println("Failed to open " + path + " to check if it's a Smithy jar: " + e.toString());

--- a/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
@@ -13,10 +13,12 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 public class Harness implements AutoCloseable {
   private File root;
   private SmithyProject project;
+  private SmithyBuildExtensions config;
 
-  private Harness(File root, SmithyProject project) {
+  private Harness(File root, SmithyProject project, SmithyBuildExtensions config) {
     this.root = root;
     this.project = project;
+    this.config = config;
   }
 
   public File getRoot() {
@@ -25,6 +27,10 @@ public class Harness implements AutoCloseable {
 
   public SmithyProject getProject() {
     return this.project;
+  }
+
+  public SmithyBuildExtensions getConfig() {
+    return this.config;
   }
 
   private static File safeCreateFile(String path, String contents, File root) throws Exception {
@@ -63,7 +69,7 @@ public class Harness implements AutoCloseable {
     File hs = Files.createTempDir();
     Either<Exception, SmithyProject> loaded = SmithyProject.load(ext, hs);
     if (loaded.isRight())
-      return new Harness(hs, loaded.getRight());
+      return new Harness(hs, loaded.getRight(), ext);
     else
       throw loaded.getLeft();
   }
@@ -76,7 +82,7 @@ public class Harness implements AutoCloseable {
     }
     Either<Exception, SmithyProject> loaded = SmithyProject.load(ext, hs);
     if (loaded.isRight())
-      return new Harness(hs, loaded.getRight());
+      return new Harness(hs, loaded.getRight(), ext);
     else
       throw loaded.getLeft();
   }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -221,6 +221,6 @@ public class SmithyTextDocumentServiceTest {
     }
 
     private String uri(File f) {
-        return "file:" + f.getAbsolutePath();
+        return f.toURI().toString();
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -207,7 +207,6 @@ public class SmithyTextDocumentServiceTest {
     }
 
     private List<PublishDiagnosticsParams> fileDiagnostics(File f, List<PublishDiagnosticsParams> diags) {
-        // println()
         return diags.stream().filter(pds -> pds.getUri().equals(uri(f))).collect(Collectors.toList());
     }
 
@@ -217,7 +216,7 @@ public class SmithyTextDocumentServiceTest {
     }
 
     private TextDocumentItem textDocumentItem(File f, String text) {
-        return new TextDocumentItem("file:" + f.getAbsolutePath(), "smithy", 1, text);
+        return new TextDocumentItem(uri(f), "smithy", 1, text);
     }
 
     private String uri(File f) {

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.ext;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Test;
+
+import software.amazon.smithy.lsp.SmithyTextDocumentService;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SetUtils;
+
+public class SmithyTextDocumentServiceTest {
+
+    @Test
+    public void correctlyAttributingDiagnostics() throws Exception {
+        String brokenFileName = "foo/broken.smithy";
+        String goodFileName = "good.smithy";
+
+        Map<String, String> files = MapUtils.ofEntries(
+                MapUtils.entry(brokenFileName, "namespace testFoo\n string_ MyId"),
+                MapUtils.entry(goodFileName, "namespace testBla"));
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty());
+            tds.createProject(hs.getConfig(), hs.getRoot());
+
+            File broken = hs.file(brokenFileName);
+            File good = hs.file(goodFileName);
+
+            // When compiling broken file
+            Set<String> filesWithDiagnostics = tds.recompile(broken, Optional.empty()).getRight().stream()
+                    .filter(pds -> (pds.getDiagnostics().size() > 0)).map(pds -> pds.getUri())
+                    .collect(Collectors.toSet());
+            assertEquals(SetUtils.of(uri(broken)), filesWithDiagnostics);
+
+            // When compiling good file
+            filesWithDiagnostics = tds.recompile(good, Optional.empty()).getRight().stream()
+                    .filter(pds -> (pds.getDiagnostics().size() > 0)).map(pds -> pds.getUri())
+                    .collect(Collectors.toSet());
+            assertEquals(SetUtils.of(uri(broken)), filesWithDiagnostics);
+
+        }
+
+    }
+
+    @Test
+    public void sendingDiagnosticsToTheClient() throws Exception {
+        String brokenFileName = "foo/broken.smithy";
+        String goodFileName = "good.smithy";
+
+        Map<String, String> files = MapUtils.ofEntries(
+                MapUtils.entry(brokenFileName, "namespace testFoo; string_ MyId"),
+                MapUtils.entry(goodFileName, "namespace testBla"));
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty());
+            StubClient client = new StubClient();
+            tds.createProject(hs.getConfig(), hs.getRoot());
+            tds.setClient(client);
+
+            File broken = hs.file(brokenFileName);
+            File good = hs.file(goodFileName);
+
+            // OPEN
+
+            tds.didOpen(new DidOpenTextDocumentParams(textDocumentItem(broken, files.get(brokenFileName))));
+
+            // broken file has a diganostic published against it
+            assertEquals(1, fileDiagnostics(broken, client.diagnostics).size());
+            assertEquals(ListUtils.of(DiagnosticSeverity.Error), getSeverities(broken, client.diagnostics));
+            // To clear diagnostics correctly, we must *explicitly* publish an empty
+            // list of diagnostics against files with no errors
+
+            assertEquals(1, fileDiagnostics(good, client.diagnostics).size());
+            assertEquals(ListUtils.of(), fileDiagnostics(good, client.diagnostics).get(0).getDiagnostics());
+
+            client.clear();
+
+            // SAVE
+
+            tds.didSave(new DidSaveTextDocumentParams(new TextDocumentIdentifier(uri(broken))));
+
+            // broken file has a diganostic published against it
+            assertEquals(1, fileDiagnostics(broken, client.diagnostics).size());
+            assertEquals(ListUtils.of(DiagnosticSeverity.Error), getSeverities(broken, client.diagnostics));
+            // To clear diagnostics correctly, we must *explicitly* publish an empty
+            // list of diagnostics against files with no errors
+            assertEquals(1, fileDiagnostics(good, client.diagnostics).size());
+            assertEquals(ListUtils.of(), fileDiagnostics(good, client.diagnostics).get(0).getDiagnostics());
+
+        }
+
+    }
+
+    @Test
+    public void handlingChanges() throws Exception {
+        String fileName1 = "foo/bla.smithy";
+        String fileName2 = "good.smithy";
+
+        Map<String, String> files = MapUtils.ofEntries(MapUtils.entry(fileName1, "namespace testFoo\n string MyId"),
+                MapUtils.entry(fileName2, "namespace testBla"));
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty());
+            StubClient client = new StubClient();
+            tds.createProject(hs.getConfig(), hs.getRoot());
+            tds.setClient(client);
+
+            File file1 = hs.file(fileName1);
+            File file2 = hs.file(fileName2);
+
+            // OPEN
+
+            tds.didChange(new DidChangeTextDocumentParams(new VersionedTextDocumentIdentifier(uri(file1), 1),
+                    ListUtils.of(new TextDocumentContentChangeEvent("nmspect broken"))));
+
+            // Only diagnostics for existing files are reported
+            assertEquals(SetUtils.of(uri(file1), uri(file2)), SetUtils.copyOf(getUris(client.diagnostics)));
+
+        }
+
+    }
+
+    private class StubClient implements LanguageClient {
+        public List<PublishDiagnosticsParams> diagnostics = new ArrayList();
+        public List<MessageParams> shown = new ArrayList();
+        public List<MessageParams> logged = new ArrayList();
+
+        public StubClient() {
+        }
+
+        public void clear() {
+            this.diagnostics.clear();
+            this.shown.clear();
+            this.logged.clear();
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+            this.diagnostics.add(diagnostics);
+        }
+
+        @Override
+        public void telemetryEvent(Object object) {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void logMessage(MessageParams message) {
+            this.logged.add(message);
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams) {
+            this.shown.add(messageParams);
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+            // TODO Auto-generated method stub
+            return null;
+        }
+    }
+
+    private Set<String> getUris(Collection<PublishDiagnosticsParams> diagnostics) {
+        return diagnostics.stream().map(uri -> uri.getUri()).collect(Collectors.toSet());
+    }
+
+    private List<PublishDiagnosticsParams> fileDiagnostics(File f, List<PublishDiagnosticsParams> diags) {
+        // println()
+        return diags.stream().filter(pds -> pds.getUri().equals(uri(f))).collect(Collectors.toList());
+    }
+
+    private List<DiagnosticSeverity> getSeverities(File f, List<PublishDiagnosticsParams> diags) {
+        return fileDiagnostics(f, diags).stream()
+                .flatMap(pds -> pds.getDiagnostics().stream().map(d -> d.getSeverity())).collect(Collectors.toList());
+    }
+
+    private TextDocumentItem textDocumentItem(File f, String text) {
+        return new TextDocumentItem("file:" + f.getAbsolutePath(), "smithy", 1, text);
+    }
+
+    private String uri(File f) {
+        return "file:" + f.getAbsolutePath();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Publish diagnostics for files that have failures in the model (not just files that triggered failed compilation)
2. Explicitly publish empty list of diagnostics for files that have no errors (to clear out between compilation)
3. Never publish diagnostics for temporary files we create during `didChange`. Instead:
    - Massage a list of validation events, to change the locations of diagnostics to point at real workspace files
    - Don't persist the model (`this.project`) if we're not working with real files (as in the case of `didOpen` and `didSave`). This prevents stale diagnostics from accumulating with every change until the user presses Save.
4. Add tests for all this nightmare.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
