### PR TITLE
Completions based on models

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +49,8 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
+
+import software.amazon.smithy.lsp.ext.Constants;
 import software.amazon.smithy.lsp.ext.LspLog;
 import software.amazon.smithy.lsp.ext.SmithyBuildExtensions;
 import software.amazon.smithy.lsp.ext.SmithyProject;
@@ -63,20 +66,15 @@ public class SmithyTextDocumentService implements TextDocumentService {
     private final List<Location> noLocations = Collections.emptyList();
     private SmithyProject project;
 
+    // when files are edited, their contents will be persisted in memory and removed
+    // on didSave or didClose
+    private Map<File, String> temporaryContents = new HashMap();
+
     /**
      * @param client Language Client to be used by text document service.
      */
     public SmithyTextDocumentService(Optional<LanguageClient> client) {
         this.client = client;
-
-        List<CompletionItem> keywordCompletions = SmithyKeywords.KEYWORDS.stream()
-                .map(kw -> create(kw, CompletionItemKind.Keyword)).collect(Collectors.toList());
-
-        List<CompletionItem> baseTypesCompletions = SmithyKeywords.BUILT_IN_TYPES.stream()
-                .map(kw -> create(kw, CompletionItemKind.Class)).collect(Collectors.toList());
-
-        baseCompletions.addAll(keywordCompletions);
-        baseCompletions.addAll(baseTypesCompletions);
     }
 
     public void setClient(LanguageClient client) {
@@ -108,6 +106,16 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
     @Override
     public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
+        LspLog.println("Asking to complete " + position + " in class " + position.getTextDocument().getClass());
+
+        try {
+            String found = findToken(position.getTextDocument().getUri(), position.getPosition());
+            LspLog.println("Token for completion: " + found + " in class " + position.getTextDocument().getClass());
+            return Utils.completableFuture(Either.forLeft(project.getCompletions(found)));
+        } catch (Exception e) {
+            LspLog.println(
+                    "Failed to identify token for completion in " + position.getTextDocument().getUri() + ": " + e);
+        }
         return Utils.completableFuture(Either.forLeft(baseCompletions));
     }
 
@@ -116,27 +124,29 @@ public class SmithyTextDocumentService implements TextDocumentService {
         return Utils.completableFuture(unresolved);
     }
 
-    private CompletionItem create(String s, CompletionItemKind kind) {
-        CompletionItem ci = new CompletionItem(s);
-        ci.setKind(kind);
-        return ci;
-    }
-
     private List<String> readAll(File f) throws IOException {
         return Files.readAllLines(f.toPath());
     }
 
     private String findToken(String path, Position p) throws IOException {
         List<String> contents;
-        LspLog.println("Looking for " + path);
         if (Utils.isSmithyJarFile(path)) {
             contents = Utils.jarFileContents(path);
         } else {
-            contents = readAll(new File(URI.create(path)));
+            String tempContents = temporaryContents.get(fileFromUri(path));
+            if (tempContents != null) {
+                LspLog.println("Path " + path + " was found in temporary buffer");
+                contents = Arrays.stream(tempContents.split("\n")).collect(Collectors.toList());
+            } else {
+                contents = readAll(new File(URI.create(path)));
+            }
+
         }
 
         String line = contents.get(p.getLine());
         int col = p.getCharacter();
+
+        LspLog.println("Trying to find a token in line '" + line + "' at position " + p);
 
         String before = line.substring(0, col);
         String after = line.substring(col, line.length());
@@ -191,9 +201,13 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
         try {
             if (params.getContentChanges().size() > 0) {
-                tempFile = File.createTempFile("smithy", SmithyProject.SMITHY_EXTENSION);
+                tempFile = File.createTempFile("smithy", Constants.SMITHY_EXTENSION);
 
-                Files.write(tempFile.toPath(), params.getContentChanges().get(0).getText().getBytes());
+                String contents = params.getContentChanges().get(0).getText();
+
+                unstableContents(fileUri(params.getTextDocument()), contents);
+
+                Files.write(tempFile.toPath(), contents.getBytes());
             }
 
         } catch (Exception ignored) {
@@ -201,6 +215,14 @@ public class SmithyTextDocumentService implements TextDocumentService {
         }
 
         report(recompile(fileUri(params.getTextDocument()), Optional.ofNullable(tempFile)));
+    }
+
+    private void stableContents(File file) {
+        this.temporaryContents.remove(file);
+    }
+
+    private void unstableContents(File file, String contents) {
+        this.temporaryContents.put(file, contents);
     }
 
     @Override
@@ -213,20 +235,28 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
     @Override
     public void didClose(DidCloseTextDocumentParams params) {
-        report(recompile(fileUri(params.getTextDocument()), Optional.empty()));
+        File file = fileUri(params.getTextDocument());
+        stableContents(file);
+        report(recompile(file, Optional.empty()));
     }
 
     @Override
     public void didSave(DidSaveTextDocumentParams params) {
-        report(recompile(fileUri(params.getTextDocument()), Optional.empty()));
+        File file = fileUri(params.getTextDocument());
+        stableContents(file);
+        report(recompile(file, Optional.empty()));
     }
 
     private File fileUri(TextDocumentIdentifier tdi) {
-        return new File(URI.create(tdi.getUri()));
+        return fileFromUri(tdi.getUri());
     }
 
     private File fileUri(TextDocumentItem tdi) {
-        return new File(URI.create(tdi.getUri()));
+        return fileFromUri(tdi.getUri());
+    }
+
+    private File fileFromUri(String uri) {
+        return new File(URI.create(uri));
     }
 
     /**

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.DefinitionParams;
@@ -49,7 +48,6 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
-
 import software.amazon.smithy.lsp.ext.Constants;
 import software.amazon.smithy.lsp.ext.LspLog;
 import software.amazon.smithy.lsp.ext.SmithyBuildExtensions;

--- a/src/main/java/software/amazon/smithy/lsp/ext/Completions.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/Completions.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.ext;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.utils.ListUtils;
+
+public final class Completions {
+    private static List<CompletionItem> keywordCompletions = Constants.KEYWORDS.stream()
+            .map(kw -> createCompletion(kw, CompletionItemKind.Keyword)).collect(Collectors.toList());
+
+    private Completions() {
+    }
+
+    /**
+     * From a model and (potentially partial) token, build a list of completions.
+     * Empty list is returned for empty tokens. Current implementation is prefix
+     * based.
+     *
+     * @param model Smithy model
+     * @param token token
+     * @return list of completion items
+     */
+    public static List<CompletionItem> find(Model model, String token) {
+        Map<String, CompletionItem> comps = new HashMap();
+        String lcase = token.toLowerCase();
+
+        if (!token.trim().isEmpty()) {
+            model.getShapeIds().forEach(shapeId -> {
+                if (shapeId.getName().toLowerCase().startsWith(lcase) && !comps.containsKey(shapeId.getName())) {
+                    CompletionItem completionItem = createCompletion(shapeId.getName(), CompletionItemKind.Class);
+                    comps.put(shapeId.getName(), completionItem);
+                }
+            });
+
+            keywordCompletions.forEach(kw -> {
+                if (kw.getLabel().toLowerCase().startsWith(lcase) && !comps.containsKey(kw.getLabel())) {
+                    comps.put(kw.getLabel(), kw);
+                }
+            });
+        }
+        return ListUtils.copyOf(comps.values());
+    }
+
+    private static CompletionItem createCompletion(String s, CompletionItemKind kind) {
+        CompletionItem ci = new CompletionItem(s);
+        ci.setKind(kind);
+        return ci;
+    }
+
+}

--- a/src/main/java/software/amazon/smithy/lsp/ext/Constants.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/Constants.java
@@ -19,8 +19,18 @@ import java.util.Arrays;
 import java.util.List;
 
 public final class Constants {
+  public static final String SMITHY_EXTENSION = ".smithy";
+
   public static final List<String> BUILD_FILES = Arrays.asList("build/smithy-dependencies.json", ".smithy.json",
       "smithy-build.json");
+
+  public static final List<String> BUILT_IN_TYPES = Arrays.asList("Blob", "Boolean", "String", "Byte", "Short",
+      "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal", "Timestamp", "Document");
+  public static final List<String> KEYWORDS = Arrays.asList("bigDecimal", "bigInteger", "blob", "boolean", "byte",
+      "create", "collectionOperations", "delete", "document", "double", "errors", "float", "identifiers", "input",
+      "integer", "integer", "key", "list", "long", "map", "member", "metadata", "namespace", "operation", "operations",
+      "output", "put", "read", "rename", "resource", "resources", "service", "set", "short", "string", "structure",
+      "timestamp", "union", "update", "use", "value", "version");
 
   private Constants() {
   }

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -28,9 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -48,19 +46,6 @@ public final class SmithyProject {
     private Map<String, List<Location>> locations = Collections.emptyMap();
     private ValidatedResult<Model> model;
     private final File root;
-
-    List<CompletionItem> keywordCompletions = Constants.KEYWORDS.stream()
-            .map(kw -> createCompletion(kw, CompletionItemKind.Keyword)).collect(Collectors.toList());
-
-    // List<CompletionItem> baseTypesCompletions = Constants.BUILT_IN_TYPES.stream()
-    // .map(kw -> createCompletion(kw,
-    // CompletionItemKind.Class)).collect(Collectors.toList());
-
-    private CompletionItem createCompletion(String s, CompletionItemKind kind) {
-        CompletionItem ci = new CompletionItem(s);
-        ci.setKind(kind);
-        return ci;
-    }
 
     private SmithyProject(List<Path> imports, List<File> smithyFiles, List<File> externalJars, File root,
             ValidatedResult<Model> model) {
@@ -105,21 +90,8 @@ public final class SmithyProject {
         return this.smithyFiles;
     }
 
-    public List<CompletionItem> getCompletions(String prefix) {
-        return this.model.getResult().map(model -> {
-            List<CompletionItem> comps = new ArrayList();
-
-            model.getShapeIds().forEach(shapeId -> {
-                if (shapeId.getName().startsWith(prefix))
-                    comps.add(createCompletion(shapeId.getName(), CompletionItemKind.Class));
-            });
-
-            keywordCompletions.forEach(kw -> {
-                if (kw.getLabel().startsWith(prefix))
-                    comps.add(kw);
-            });
-            return comps;
-        }).orElse(Collections.emptyList());
+    public List<CompletionItem> getCompletions(String token) {
+        return this.model.getResult().map(model -> Completions.find(model, token)).orElse(Collections.emptyList());
     }
 
     public Map<String, List<Location>> getLocations() {

--- a/src/test/java/software/amazon/smithy/lsp/ext/CompletionTests.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/CompletionTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.ext;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SetUtils;
+
+public class CompletionTests {
+
+    @Test
+    public void multiFile() throws Exception {
+
+        String def1 = "namespace test\nstring MyId";
+        String def2 = "namespace test\nstructure Hello{}\ninteger MyId2";
+        String def3 = "namespace test\n@trait\nstructure Foo {}";
+        Map<String, String> files = MapUtils.ofEntries(MapUtils.entry("def1.smithy", def1),
+                MapUtils.entry("bar/def2.smithy", def2), MapUtils.entry("foo/hello/def3.smithy", def3));
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
+            SmithyProject proj = hs.getProject();
+            // Complete match
+            assertEquals(SetUtils.of("Foo"), completeNames(proj, "Foo"));
+            // Partial match
+            assertEquals(SetUtils.of("MyId", "MyId2"), completeNames(proj, "MyI"));
+            // Partial match (case insensitive)
+            assertEquals(SetUtils.of("MyId", "MyId2"), completeNames(proj, "myi"));
+
+            // no matches
+            assertEquals(SetUtils.of(), completeNames(proj, "basdasdasdasd"));
+            // empty token
+            assertEquals(SetUtils.of(), completeNames(proj, ""));
+            // built-in
+            assertEquals(SetUtils.of("string", "String"), completeNames(proj, "Strin"));
+            assertEquals(SetUtils.of("integer", "Integer"), completeNames(proj, "integer"));
+            assertEquals(SetUtils.of("trait", "TraitShapeId", "TraitShapeIdList"), completeNames(proj, "trai"));
+
+        }
+
+    }
+
+    public Set<String> completeNames(SmithyProject proj, String token) {
+        return proj.getCompletions(token).stream().map(ci -> ci.getLabel()).collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -62,8 +62,8 @@ public class SmithyProjectTest {
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
 
             List<File> expectedFiles = Files.walk(hs.getRoot().toPath())
-                    .filter(f -> f.getFileName().toString().endsWith(SmithyProject.SMITHY_EXTENSION))
-                    .map(Path::toFile).collect(Collectors.toList());
+                    .filter(f -> f.getFileName().toString().endsWith(Constants.SMITHY_EXTENSION)).map(Path::toFile)
+                    .collect(Collectors.toList());
 
             List<File> smithyFiles = hs.getProject().getSmithyFiles();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

WIP: Completions based on the actual model

TODO:

- [ ] Persist previously working model - so that when you break it, you still have **some** completions working (Smithy doesn't do partial models, if there are any errors)
- [x] tests
- [ ] (descoped for a future PR) .startsWith can be refined - we can use Levenstein distance and choose top 10 candidates with lowest distance (this decision can be made based on length of prefix)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
