### PR TITLE
Improve working with temporary buffers

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +49,8 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
 
   private Optional<LanguageClient> client = Optional.empty();
 
-  private File workspaceRoot = null;
+  private File workspaceRoot;
+  // private File tempFolder = ;
 
   private Optional<SmithyTextDocumentService> tds = Optional.empty();
 
@@ -129,7 +131,15 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
 
   @Override
   public TextDocumentService getTextDocumentService() {
-    SmithyTextDocumentService local = new SmithyTextDocumentService(this.client);
+    File temp = null;
+    try {
+      temp = Files.createTempDirectory("smithy-lsp").toFile();
+      LspLog.println("Created a temporary folder for file contents " + temp);
+      temp.deleteOnExit();
+    } catch (IOException e) {
+      LspLog.println("Failed to create a temporary folder " + e);
+    }
+    SmithyTextDocumentService local = new SmithyTextDocumentService(this.client, temp);
     tds = Optional.of(local);
     return local;
   }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -321,10 +321,8 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
         List<PublishDiagnosticsParams> diagnostics = new ArrayList<PublishDiagnosticsParams>();
 
-        byFile.entrySet().forEach(e -> {
-            diagnostics.add(createDiagnostics(e.getKey().toURI().toString(),
-                    e.getValue().stream().map(ProtocolAdapter::toDiagnostic).collect(Collectors.toList())));
-        });
+        byFile.forEach((key, value) -> diagnostics.add(createDiagnostics(key.toURI().toString(),
+                value.stream().map(ProtocolAdapter::toDiagnostic).collect(Collectors.toList()))));
 
         return diagnostics;
 
@@ -342,7 +340,7 @@ public class SmithyTextDocumentService implements TextDocumentService {
     public Either<String, List<PublishDiagnosticsParams>> recompile(File path, Optional<File> temporary) {
         // File latestContents = temporary.orElse(path);
         Either<Exception, SmithyProject> loadedModel;
-        if (temporary.isEmpty()) {
+        if (!temporary.isPresent()) {
             // if there's no temporary file present (didOpen/didClose/didSave)
             // we want to rebuild the model with the original path
             // optionally removing a temporary file

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -15,9 +15,12 @@
 
 package software.amazon.smithy.lsp;
 
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
@@ -63,16 +67,22 @@ public class SmithyTextDocumentService implements TextDocumentService {
     private Optional<LanguageClient> client = Optional.empty();
     private final List<Location> noLocations = Collections.emptyList();
     private SmithyProject project;
+    private File temporaryFolder;
 
     // when files are edited, their contents will be persisted in memory and removed
     // on didSave or didClose
-    private Map<File, String> temporaryContents = new HashMap();
+    private Map<File, String> temporaryContents = new ConcurrentHashMap<>();
+
+    // We use this function to has filepaths to the same location in temporary
+    // folder
+    private HashFunction hash = Hashing.murmur3_128();
 
     /**
      * @param client Language Client to be used by text document service.
      */
-    public SmithyTextDocumentService(Optional<LanguageClient> client) {
+    public SmithyTextDocumentService(Optional<LanguageClient> client, File tempFile) {
         this.client = client;
+        this.temporaryFolder = tempFile;
     }
 
     public void setClient(LanguageClient client) {
@@ -124,6 +134,12 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
     private List<String> readAll(File f) throws IOException {
         return Files.readAllLines(f.toPath());
+    }
+
+    private File designatedTemporaryFile(File source) {
+        String hashed = hash.hashString(source.getAbsolutePath(), StandardCharsets.UTF_8).toString();
+
+        return new File(this.temporaryFolder, hashed + Constants.SMITHY_EXTENSION);
     }
 
     private String findToken(String path, Position p) throws IOException {
@@ -195,24 +211,25 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
     @Override
     public void didChange(DidChangeTextDocumentParams params) {
+        File original = fileUri(params.getTextDocument());
         File tempFile = null;
 
         try {
             if (params.getContentChanges().size() > 0) {
-                tempFile = File.createTempFile("smithy", Constants.SMITHY_EXTENSION);
-
+                tempFile = designatedTemporaryFile(original);
                 String contents = params.getContentChanges().get(0).getText();
 
-                unstableContents(fileUri(params.getTextDocument()), contents);
+                unstableContents(original, contents);
 
                 Files.write(tempFile.toPath(), contents.getBytes());
             }
 
-        } catch (Exception ignored) {
-
+        } catch (Exception e) {
+            LspLog.println("Failed to write temporary contents for file " + original + " into temporary file "
+                    + tempFile + " : " + e);
         }
 
-        report(recompile(fileUri(params.getTextDocument()), Optional.ofNullable(tempFile)));
+        report(recompile(original, Optional.ofNullable(tempFile)));
     }
 
     private void stableContents(File file) {
@@ -220,6 +237,7 @@ public class SmithyTextDocumentService implements TextDocumentService {
     }
 
     private void unstableContents(File file, String contents) {
+        LspLog.println("Hashed filename " + file + " into " + designatedTemporaryFile(file));
         this.temporaryContents.put(file, contents);
     }
 
@@ -322,8 +340,20 @@ public class SmithyTextDocumentService implements TextDocumentService {
      * @return either a fatal error message, or a list of diagnostics
      */
     public Either<String, List<PublishDiagnosticsParams>> recompile(File path, Optional<File> temporary) {
-        File latestContents = temporary.orElse(path);
-        Either<Exception, SmithyProject> loadedModel = this.project.recompile(latestContents);
+        // File latestContents = temporary.orElse(path);
+        Either<Exception, SmithyProject> loadedModel;
+        if (temporary.isEmpty()) {
+            // if there's no temporary file present (didOpen/didClose/didSave)
+            // we want to rebuild the model with the original path
+            // optionally removing a temporary file
+            // This protects against a conflict during the didChange -> didSave sequence
+            loadedModel = this.project.recompile(path, designatedTemporaryFile(path));
+        } else {
+            // If there's a temporary file present (didChange), we want to
+            // replace the original path with a temporary one (to avoid conflicting
+            // definitions)
+            loadedModel = this.project.recompile(temporary.get(), path);
+        }
 
         if (loadedModel.isLeft()) {
             return Either.forLeft(path + " is not okay!" + loadedModel.getLeft().toString());
@@ -360,7 +390,8 @@ public class SmithyTextDocumentService implements TextDocumentService {
             }
 
             LspLog.println(
-                    "Recompiling " + path + " (with temporary content " + temporary + ") raised diagnostics:" + events);
+                    "Recompiling " + path + " (with temporary content " + temporary + ") raised " + events.size()
+                            + "  diagnostics");
             return Either.forRight(createPerFileDiagnostics(events, allFiles));
         }
 

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -48,7 +49,7 @@ public final class SmithyProject {
     private final File root;
 
     private SmithyProject(List<Path> imports, List<File> smithyFiles, List<File> externalJars, File root,
-            ValidatedResult<Model> model) {
+                          ValidatedResult<Model> model) {
         this.imports = imports;
         this.root = root;
         this.model = model;
@@ -60,19 +61,26 @@ public final class SmithyProject {
     }
 
     /**
-     * Recompile the model, optionally adding a file to the tracked list of sources.
+     * Recompile the model, adding a file to list of tracked files, potentially
+     * excluding some other file.
+     * <p>
+     * This version of the method above is used when the
+     * file is in ephemeral storage (temporary location when file is being changed)
      *
-     * @param file file which may or may not be already tracked by this project
+     * @param changed file which may or may not be already tracked by this project
      * @return either an error, or a loaded project
      */
-    public Either<Exception, SmithyProject> recompile(File file) {
+    public Either<Exception, SmithyProject> recompile(File changed, File exclude) {
+        List<File> newFiles = new ArrayList<File>();
 
-        // We aggressively re-build the model with only existing files
-        // it's simpler than trying to manage which file was added/removed/closed etc.
-        List<File> newFiles = new ArrayList<File>(onlyExistingFiles(this.smithyFiles));
+        for (File existing : onlyExistingFiles(this.smithyFiles)) {
+            if (exclude != null && !existing.equals(exclude)) {
+                newFiles.add(existing);
+            }
+        }
 
-        if (file.isFile()) {
-            newFiles.add(file);
+        if (changed.isFile()) {
+            newFiles.add(changed);
         }
 
         return load(this.imports, newFiles, this.externalJars, this.root);
@@ -131,7 +139,7 @@ public final class SmithyProject {
     }
 
     private static Either<Exception, SmithyProject> load(List<Path> imports, List<File> smithyFiles,
-            List<File> externalJars, File root) {
+                                                         List<File> externalJars, File root) {
         Either<Exception, ValidatedResult<Model>> model = createModel(smithyFiles, externalJars);
 
         if (model.isLeft()) {
@@ -142,7 +150,7 @@ public final class SmithyProject {
     }
 
     private static Either<Exception, ValidatedResult<Model>> createModel(List<File> discoveredFiles,
-            List<File> externalJars) {
+                                                                         List<File> externalJars) {
         return SmithyInterface.readModel(discoveredFiles, externalJars);
     }
 

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -49,7 +48,7 @@ public final class SmithyProject {
     private final File root;
 
     private SmithyProject(List<Path> imports, List<File> smithyFiles, List<File> externalJars, File root,
-                          ValidatedResult<Model> model) {
+            ValidatedResult<Model> model) {
         this.imports = imports;
         this.root = root;
         this.model = model;
@@ -139,7 +138,7 @@ public final class SmithyProject {
     }
 
     private static Either<Exception, SmithyProject> load(List<Path> imports, List<File> smithyFiles,
-                                                         List<File> externalJars, File root) {
+            List<File> externalJars, File root) {
         Either<Exception, ValidatedResult<Model>> model = createModel(smithyFiles, externalJars);
 
         if (model.isLeft()) {
@@ -150,7 +149,7 @@ public final class SmithyProject {
     }
 
     private static Either<Exception, ValidatedResult<Model>> createModel(List<File> discoveredFiles,
-                                                                         List<File> externalJars) {
+            List<File> externalJars) {
         return SmithyInterface.readModel(discoveredFiles, externalJars);
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -60,7 +60,7 @@ public class SmithyTextDocumentServiceTest {
                 MapUtils.entry(goodFileName, "namespace testBla"));
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
-            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty());
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
             tds.createProject(hs.getConfig(), hs.getRoot());
 
             File broken = hs.file(brokenFileName);
@@ -92,7 +92,7 @@ public class SmithyTextDocumentServiceTest {
                 MapUtils.entry(goodFileName, "namespace testBla"));
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
-            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty());
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
             StubClient client = new StubClient();
             tds.createProject(hs.getConfig(), hs.getRoot());
             tds.setClient(client);
@@ -140,7 +140,7 @@ public class SmithyTextDocumentServiceTest {
                 MapUtils.entry(fileName2, "namespace testBla"));
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
-            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty());
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
             StubClient client = new StubClient();
             tds.createProject(hs.getConfig(), hs.getRoot());
             tds.setClient(client);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix `too many open files` error by hashing absolute path of each file into the same location on disk (temporary folder)
- Fix "conflicting definitions found in `original path` and `temporary file`" by defensively removing either path from the model during rebuilding

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
