### PR TITLE
Change the way models are loaded in order to get custom validation 

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
@@ -74,10 +74,6 @@ public final class SmithyInterface {
       // Adding the model that was loaded from upstream dependencies.
       assembler.addModel(builder.build());
 
-      for (File jar : externalJars) {
-        assembler = assembler.addImport(jar.getAbsolutePath());
-      }
-
       for (File file : files) {
         assembler = assembler.addImport(file.getAbsolutePath());
       }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
@@ -16,42 +16,83 @@
 package software.amazon.smithy.lsp;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.validation.ValidatedResult;
 
 public final class SmithyInterface {
-    private SmithyInterface() {
+  private SmithyInterface() {
 
+  }
+
+  /**
+   * Reads the model in a specified file, adding external jars to model builder.
+   *
+   * @param files        list of smithy files
+   * @param externalJars set of external jars
+   * @return either an exception encountered during model building, or the result
+   *         of model building
+   */
+  public static Either<Exception, ValidatedResult<Model>> readModel(Collection<File> files,
+      Collection<File> externalJars) {
+
+    try {
+      Model.Builder builder = Model.builder();
+
+      List<URL> urls = files.stream().map(SmithyInterface::fileToUrl).collect(Collectors.toList());
+      URL[] urlArray = urls.toArray(new URL[urls.size()]);
+
+      if (urlArray.length > 0) {
+        // Loading the model just from upstream dependencies, in isolation, and adding
+        // all its
+        // shapes to the builder.
+        //
+        // Contrary to model assemblers, model builders do not complain about the
+        // duplication
+        // of shapes. Shapes will simply overwrite each other in a "last write wins"
+        // kind of way.
+
+        URLClassLoader urlClassLoader = new URLClassLoader(urlArray);
+        Model upstreamModel = Model.assembler().discoverModels(urlClassLoader).assemble().unwrap();
+        builder.addShapes(upstreamModel);
+      }
+
+      ModelAssembler assembler;
+      if (urlArray.length > 0) {
+        URLClassLoader validatorClassLoader = new URLClassLoader(urlArray, Model.class.getClassLoader());
+        assembler = Model.assembler(validatorClassLoader);
+      } else {
+        assembler = Model.assembler();
+      }
+      // Adding the model that was loaded from upstream dependencies.
+      assembler.addModel(builder.build());
+
+      for (File jar : externalJars) {
+        assembler = assembler.addImport(jar.getAbsolutePath());
+      }
+
+      for (File file : files) {
+        assembler = assembler.addImport(file.getAbsolutePath());
+      }
+
+      return Either.forRight(assembler.assemble());
+    } catch (Exception e) {
+      return Either.forLeft(e);
     }
+  }
 
-    /**
-     * Reads the model in a specified file, adding external jars to model builder.
-     *
-     * @param files        list of smithy files
-     * @param externalJars set of external jars
-     * @return either an exception encountered during model building, or the result
-     *         of model building
-     */
-    public static Either<Exception, ValidatedResult<Model>> readModel(Collection<File> files,
-            Collection<File> externalJars) {
-
-        try {
-            ModelAssembler assembler = Model.assembler().discoverModels();
-
-            for (File jar : externalJars) {
-                assembler = assembler.addImport(jar.getAbsolutePath());
-            }
-
-            for (File file : files) {
-                assembler = assembler.addImport(file.getAbsolutePath());
-            }
-
-            return Either.forRight(assembler.assemble());
-        } catch (Exception e) {
-            return Either.forLeft(e);
-        }
+  private static URL fileToUrl(File file) {
+    try {
+      return file.toURI().toURL();
+    } catch (MalformedURLException e) {
+      throw new RuntimeException("Failed to get file's URL", e);
     }
+  }
 }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
@@ -21,14 +21,12 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import software.amazon.smithy.lsp.ext.LspLog;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.validation.ValidatedResult;
-import software.amazon.smithy.model.validation.Validator;
 
 public final class SmithyInterface {
   private SmithyInterface() {

--- a/src/main/java/software/amazon/smithy/lsp/ext/DependencyDownloader.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/DependencyDownloader.java
@@ -24,9 +24,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.jar.JarFile;
 import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
 
 public final class DependencyDownloader {
   private Fetch fetch;
@@ -67,24 +65,7 @@ public final class DependencyDownloader {
     return new DependencyDownloader(extensions);
   }
 
-  private Boolean isSmithyJar(String path) {
-    try {
-      JarFile jar = new JarFile(new File(path));
-      ZipEntry manifestEntry = jar.getEntry("META-INF/smithy/manifest");
-      LspLog.println("Successfully found Smithy manifest in " + path);
-      return manifestEntry != null;
-    } catch (Exception e) {
-      LspLog.println("Failed to open " + path + " to check if it's a Smithy jar: " + e.toString());
-      return false;
-    }
-
-  }
-
-  private List<File> filterOutSmithyJars(List<File> jars) {
-    return jars.stream().filter(file -> isSmithyJar(file.getAbsolutePath())).collect(Collectors.toList());
-  }
-
   public List<File> download() throws CoursierError {
-    return filterOutSmithyJars(fetch.fetch());
+    return fetch.fetch();
   }
 }

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -144,6 +144,7 @@ public final class SmithyProject {
         if (model.isLeft()) {
             return Either.forLeft(model.getLeft());
         } else {
+            model.getRight().getValidationEvents().forEach(event -> LspLog.println(event));
             return Either.forRight(new SmithyProject(imports, smithyFiles, externalJars, root, model.getRight()));
         }
     }


### PR DESCRIPTION
Changes the way models are loaded in order for custom validation rules contained by maven dependencies to appear in the editor. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
