### PR TITLE
Reload build on file changes

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -20,20 +20,15 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CompletionOptions;
-import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
-import org.eclipse.lsp4j.Registration;
-import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
@@ -43,12 +38,8 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
-import software.amazon.smithy.lsp.ext.Constants;
 import software.amazon.smithy.lsp.ext.LspLog;
-import software.amazon.smithy.lsp.ext.SmithyBuildExtensions;
-import software.amazon.smithy.lsp.ext.SmithyBuildLoader;
 import software.amazon.smithy.lsp.ext.ValidationException;
-import software.amazon.smithy.utils.ListUtils;
 
 public class SmithyLanguageServer implements LanguageServer, LanguageClientAware, SmithyProtocolExtensions {
 

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -101,7 +101,8 @@ public class SmithyTextDocumentService implements TextDocumentService {
      * 1. Downloads external dependencies as jars 2. Creates a model from just
      * external jars 3. Updates locations index with symbols found in external jars
      *
-     * @param ext extensions
+     * @param ext  extensions
+     * @param root workspace root
      */
     public void createProject(SmithyBuildExtensions ext, File root) {
         Either<Exception, SmithyProject> loaded = SmithyProject.load(ext, root);
@@ -115,6 +116,11 @@ public class SmithyTextDocumentService implements TextDocumentService {
         }
     }
 
+    /**
+     * Discovers Smithy build files and loads the smithy project defined by them.
+     *
+     * @param root workspace root
+     */
     public void createProject(File root) {
         LspLog.println("Recreating project from " + root);
         SmithyBuildExtensions.Builder result = SmithyBuildExtensions.builder();

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -107,6 +107,7 @@ public class SmithyTextDocumentService implements TextDocumentService {
         Either<Exception, SmithyProject> loaded = SmithyProject.load(ext, root);
         if (loaded.isRight()) {
             this.project = loaded.getRight();
+            clearAllDiagnostics();
             sendInfo("Project loaded with " + this.project.getExternalJars().size() + " external jars and "
                     + this.project.getSmithyFiles().size() + " discovered smithy files");
         } else {
@@ -361,6 +362,11 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
         return diagnostics;
 
+    }
+
+    public void clearAllDiagnostics() {
+        report(Either.forRight(createPerFileDiagnostics(this.project.getModel().getValidationEvents(),
+                this.project.getSmithyFiles())));
     }
 
     /**

--- a/src/main/java/software/amazon/smithy/lsp/SmithyWorkspaceService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyWorkspaceService.java
@@ -15,14 +15,40 @@
 
 package software.amazon.smithy.lsp;
 
+import java.io.File;
+import java.net.URI;
+import java.util.Optional;
+
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
+import software.amazon.smithy.lsp.ext.Constants;
+import software.amazon.smithy.lsp.ext.LspLog;
+
 public class SmithyWorkspaceService implements WorkspaceService {
+  private Optional<SmithyTextDocumentService> tds = Optional.empty();
+
+  public SmithyWorkspaceService(Optional<SmithyTextDocumentService> tds) {
+    this.tds = tds;
+  }
+
   @Override
   public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
-    // TODO Auto-generated method stub
+
+    Boolean buildFilesChanged = params.getChanges().stream().anyMatch(change -> {
+      String filename = fileFromUri(change.getUri()).getName();
+      return Constants.BUILD_FILES.contains(filename);
+    });
+
+    if (buildFilesChanged) {
+      LspLog.println("Build files changed, rebuilding the project");
+      this.tds.ifPresent(tds -> {
+        tds.getRoot().ifPresent(root -> {
+          tds.createProject(root);
+        });
+      });
+    }
 
   }
 
@@ -31,4 +57,9 @@ public class SmithyWorkspaceService implements WorkspaceService {
     // TODO Auto-generated method stub
 
   }
+
+  private File fileFromUri(String uri) {
+    return new File(URI.create(uri));
+  }
+
 }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyWorkspaceService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyWorkspaceService.java
@@ -18,48 +18,46 @@ package software.amazon.smithy.lsp;
 import java.io.File;
 import java.net.URI;
 import java.util.Optional;
-
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.services.WorkspaceService;
-
 import software.amazon.smithy.lsp.ext.Constants;
 import software.amazon.smithy.lsp.ext.LspLog;
 
 public class SmithyWorkspaceService implements WorkspaceService {
-  private Optional<SmithyTextDocumentService> tds = Optional.empty();
+    private Optional<SmithyTextDocumentService> tds = Optional.empty();
 
-  public SmithyWorkspaceService(Optional<SmithyTextDocumentService> tds) {
-    this.tds = tds;
-  }
-
-  @Override
-  public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
-
-    Boolean buildFilesChanged = params.getChanges().stream().anyMatch(change -> {
-      String filename = fileFromUri(change.getUri()).getName();
-      return Constants.BUILD_FILES.contains(filename);
-    });
-
-    if (buildFilesChanged) {
-      LspLog.println("Build files changed, rebuilding the project");
-      this.tds.ifPresent(tds -> {
-        tds.getRoot().ifPresent(root -> {
-          tds.createProject(root);
-        });
-      });
+    public SmithyWorkspaceService(Optional<SmithyTextDocumentService> tds) {
+        this.tds = tds;
     }
 
-  }
+    @Override
+    public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
 
-  @Override
-  public void didChangeConfiguration(DidChangeConfigurationParams params) {
-    // TODO Auto-generated method stub
+        boolean buildFilesChanged = params.getChanges().stream().anyMatch(change -> {
+            String filename = fileFromUri(change.getUri()).getName();
+            return Constants.BUILD_FILES.contains(filename);
+        });
 
-  }
+        if (buildFilesChanged) {
+            LspLog.println("Build files changed, rebuilding the project");
+            this.tds.ifPresent(tds -> {
+                tds.getRoot().ifPresent(root -> {
+                    tds.createProject(root);
+                });
+            });
+        }
 
-  private File fileFromUri(String uri) {
-    return new File(URI.create(uri));
-  }
+    }
+
+    @Override
+    public void didChangeConfiguration(DidChangeConfigurationParams params) {
+        // TODO Auto-generated method stub
+
+    }
+
+    private File fileFromUri(String uri) {
+        return new File(URI.create(uri));
+    }
 
 }

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import coursierapi.shaded.coursier.core.Versions.DateTime;
 import software.amazon.smithy.utils.ListUtils;
 
 /**
@@ -54,7 +52,7 @@ public final class LspLog {
 
     /**
      * Produces a snapshot of the current log buffer.
-     * 
+     *
      * @return a copy of the messages currently in the buffer
      */
     public static List<Object> getBuffer() {

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -19,10 +19,14 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import coursierapi.shaded.coursier.core.Versions.DateTime;
 import software.amazon.smithy.utils.ListUtils;
 
 /**
@@ -50,6 +54,7 @@ public final class LspLog {
 
     /**
      * Produces a snapshot of the current log buffer.
+     * 
      * @return a copy of the messages currently in the buffer
      */
     public static List<Object> getBuffer() {
@@ -77,18 +82,23 @@ public final class LspLog {
 
     }
 
+    private static String currentTime() {
+        return LocalTime.now().withNano(0).format(DateTimeFormatter.ISO_LOCAL_TIME);
+    }
+
     /**
      * Write a line to the log.
      *
      * @param message object to write, will be converted to String
      */
     public static void println(Object message) {
+        String timestamped = "[" + currentTime() + "] " + message.toString();
         try {
             if (fw != null) {
-                fw.append(message.toString() + "\n").flush();
+                fw.append(timestamped + "\n").flush();
             } else {
                 synchronized (buffer) {
-                    buffer.ifPresent(buf -> buf.add(message));
+                    buffer.ifPresent(buf -> buf.add(timestamped));
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -154,6 +154,10 @@ public final class SmithyProject {
         return SmithyInterface.readModel(discoveredFiles, externalJars);
     }
 
+    public File getRoot() {
+        return this.root;
+    }
+
     private static Map<String, List<Location>> collectLocations(Model model) {
         Map<String, List<Location>> locations = new HashMap<>();
         model.shapes().forEach(shape -> {

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -219,6 +219,7 @@ public final class SmithyProject {
     }
 
     private static List<File> downloadExternalDependencies(SmithyBuildExtensions ext) {
+        LspLog.println("Downloading external dependencies for " + ext);
         try {
             return DependencyDownloader.create(ext).download();
         } catch (Exception e) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When we get a `didChangeWatchedFiles` type of notification, we should verify that it's from smithy build files and if so, rebuild the project from scratch with new information.

Additionally, we add more diagnostics when, say, the build file failed to parse.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
