### PR TITLE
Follow jar diagnostic

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -64,6 +64,22 @@ public final class Utils {
     }
 
     /**
+     * @param uri String
+     * @return Returns whether the uri points to a file in jar.
+     */
+    public static boolean isJarFile(String uri) {
+        return uri.startsWith("jar:");
+    }
+
+    /**
+     * @param uri String
+     * @return Remove the jar:file: part and replace it with "smithyjar"
+     */
+    public static String toSmithyJarFile(String uri) {
+        return "smithyjar:" + uri.substring(9);
+    }
+
+    /**
      * @param rawUri String
      * @return Returns whether the uri points to a file in the filesystem (as
      * opposed to a file in a jar).
@@ -111,7 +127,7 @@ public final class Utils {
     }
 
     /**
-     * Extracts just the .jar pat from a URI.
+     * Extracts just the .jar part from a URI.
      *
      * @param rawUri URI of a symbol/file in a jar
      * @return Jar path

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -163,10 +163,10 @@ public final class SmithyProject {
         model.shapes().forEach(shape -> {
             SourceLocation sourceLocation = shape.getSourceLocation();
             String fileName = sourceLocation.getFilename();
-            String uri = Utils.isJarFile(fileName) ?
-                Utils.toSmithyJarFile(fileName) :
-                !fileName.startsWith("file:") ? "file:" + fileName :
-                fileName;
+            String uri = Utils.isJarFile(fileName)
+                ? Utils.toSmithyJarFile(fileName)
+                : !fileName.startsWith("file:") ? "file:" + fileName
+                : fileName;
 
             Position pos = new Position(sourceLocation.getLine() - 1, sourceLocation.getColumn() - 1);
             Location location = new Location(uri, new Range(pos, pos));

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -33,6 +33,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import software.amazon.smithy.lsp.SmithyInterface;
+import software.amazon.smithy.lsp.Utils;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -161,12 +162,12 @@ public final class SmithyProject {
         Map<String, List<Location>> locations = new HashMap<>();
         model.shapes().forEach(shape -> {
             SourceLocation sourceLocation = shape.getSourceLocation();
-            String uri = sourceLocation.getFilename();
-            if (uri.startsWith("jar:file:")) {
-                uri = "smithyjar:" + uri.substring(9);
-            } else if (!uri.startsWith("file:")) {
-                uri = "file:" + uri;
-            }
+            String fileName = sourceLocation.getFilename();
+            String uri = Utils.isJarFile(fileName) ?
+                Utils.toSmithyJarFile(fileName) :
+                !fileName.startsWith("file:") ? "file:" + fileName :
+                fileName;
+
             Position pos = new Position(sourceLocation.getLine() - 1, sourceLocation.getColumn() - 1);
             Location location = new Location(uri, new Range(pos, pos));
 


### PR DESCRIPTION
*Issue #, if available:*

when clicking on a diagnostic that happens to be in a jar, opening the file fails

*Description of changes:*

we have a custom text content provider that relies on smithyjar to load jar file in the buffer. but it is not used in this context for two reason:

- the file path originally is jar:file:.... and so the original logic prepend `file:`
- raising into File and then calling .toUri prepend the user.dir system properties

to avoid these we:

- use URI instead of a File
- if in a jar, transform to the smithyjar content provider
- if not prefixed with file: we prefix it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
