### PR TITLE
Avoid importing stuff from current namespace

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/ext/Completions.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/Completions.java
@@ -80,15 +80,19 @@ public final class Completions {
             CompletionItem result = sci.getCompletionItem();
             Optional<String> qualifiedImport = sci.getQualifiedImport();
             Optional<String> importNamespace = sci.getImportNamespace();
+            Optional<String> currentNamespace = preamble.getCurrentNamespace();
 
-            boolean shouldImport = qualifiedImport.isPresent()
-                    && !preamble.hasImport(qualifiedImport.get())
-                    && !importNamespace.equals(Optional.of(Constants.SMITHY_PRELUDE_NAMESPACE));
 
-            if (shouldImport) {
-                TextEdit te = Document.insertPreambleLine("use " + qualifiedImport.get(), preamble);
-                result.setAdditionalTextEdits(ListUtils.of(te));
-            }
+            qualifiedImport.ifPresent(qi -> {
+                boolean matchesCurrent = importNamespace.equals(currentNamespace);
+                boolean matchesPrelude = importNamespace.equals(Optional.of(Constants.SMITHY_PRELUDE_NAMESPACE));
+                boolean shouldImport = !preamble.hasImport(qi) && !matchesPrelude && !matchesCurrent;
+
+                if (shouldImport) {
+                    TextEdit te = Document.insertPreambleLine("use " + qualifiedImport.get(), preamble);
+                    result.setAdditionalTextEdits(ListUtils.of(te));
+                }
+            });
 
             return result;
         }).collect(Collectors.toList());

--- a/src/main/java/software/amazon/smithy/lsp/ext/Document.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/Document.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.lsp.ext;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -45,9 +46,12 @@ public final class Document {
         // First, we detect the namespace and use block in a very ugly way
         boolean collectUseBlock = true;
         int lineNumber = 0;
+        Optional<String> currentNamespace = Optional.empty();
         for (String line : lines) {
-            if (line.trim().startsWith("namespace ")) {
+            final String namespaceAnchor = "namespace ";
+            if (line.trim().startsWith(namespaceAnchor)) {
                 if (namespace.getStart() == blankPosition) {
+                    currentNamespace = Optional.of(line.trim().substring(namespaceAnchor.length()));
                     namespace.setStart(new Position(lineNumber, 0));
                     namespace.setEnd(new Position(lineNumber, line.length() - 1));
                 }
@@ -92,7 +96,7 @@ public final class Document {
             }
         }
 
-        return new DocumentPreamble(namespace, useBlock, imports, blankSeparated);
+        return new DocumentPreamble(currentNamespace, namespace, useBlock, imports, blankSeparated);
     }
 
     /**

--- a/src/main/java/software/amazon/smithy/lsp/ext/DocumentPreamble.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/DocumentPreamble.java
@@ -15,10 +15,12 @@
 
 package software.amazon.smithy.lsp.ext;
 
+import java.util.Optional;
 import java.util.Set;
 import org.eclipse.lsp4j.Range;
 
 public final class DocumentPreamble {
+    private final Optional<String> currentNamespace;
     private final Range namespace;
     private final Range useBlock;
     private final Set<String> imports;
@@ -29,12 +31,18 @@ public final class DocumentPreamble {
      * This information is required to correctly implement features such as auto-import of definitions
      * on completions.
      *
+     * @param currentNamespace namespace value in the document
      * @param namespace      position of namespace declaration
      * @param useBlock       start and end of the use statements block
      * @param imports        set of imported (fully qualified) identifiers
      * @param blankSeparated whether document preamble is separated from other definitions by newline(s)
      */
-    public DocumentPreamble(Range namespace, Range useBlock, Set<String> imports, boolean blankSeparated) {
+    public DocumentPreamble(
+        Optional<String> currentNamespace,
+        Range namespace, Range useBlock, Set<String> imports,
+        boolean blankSeparated
+    ) {
+        this.currentNamespace = currentNamespace;
         this.namespace = namespace;
         this.useBlock = useBlock;
         this.imports = imports;
@@ -55,6 +63,10 @@ public final class DocumentPreamble {
 
     public boolean isBlankSeparated() {
         return this.blankSeparated;
+    }
+
+    public Optional<String> getCurrentNamespace() {
+        return this.currentNamespace;
     }
 
     @Override


### PR DESCRIPTION
*Issue #, if available:*

auto-completion import stuff that is in the current namespace

*Description of changes:*

keep track of the namespace of the current document (if available) in the document preamble

check whether the imported namespace matches the current, if it does, discard the import

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
