### PR TITLE
Expose validator name to use in suppressions

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/ProtocolAdapter.java
+++ b/src/main/java/software/amazon/smithy/lsp/ProtocolAdapter.java
@@ -39,7 +39,7 @@ public final class ProtocolAdapter {
 
     Range range = new Range(new Position(line, 0), new Position(line, col));
 
-    final String message = event.getMessage() + " - " + event.getId();
+    final String message = event.getId() + ": " + event.getMessage();
 
     return new Diagnostic(range, message, severity, "Smithy LSP");
   }

--- a/src/main/java/software/amazon/smithy/lsp/ProtocolAdapter.java
+++ b/src/main/java/software/amazon/smithy/lsp/ProtocolAdapter.java
@@ -39,7 +39,9 @@ public final class ProtocolAdapter {
 
     Range range = new Range(new Position(line, 0), new Position(line, col));
 
-    return new Diagnostic(range, event.getMessage(), severity, "Smithy LSP");
+    final String message = event.getMessage() + " - " + event.getId();
+
+    return new Diagnostic(range, message, severity, "Smithy LSP");
   }
 
   /**

--- a/src/test/java/software/amazon/smithy/lsp/ext/ProtocolAdapterTests.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/ProtocolAdapterTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp;
+
+import org.eclipse.lsp4j.Diagnostic;
+import static software.amazon.smithy.model.validation.Severity.WARNING;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ProtocolAdapterTests {
+	@Test
+	public void addIdToDiagnostic() throws Exception {
+		final ValidationEvent vEvent = ValidationEvent.builder()
+			.message("Ooops")
+			.id("should-show-up")
+			.severity(WARNING)
+			.build();
+		final Diagnostic actual = ProtocolAdapter.toDiagnostic(vEvent);
+		assertEquals("Ooops - should-show-up", actual.getMessage());
+	}
+}

--- a/src/test/java/software/amazon/smithy/lsp/ext/ProtocolAdapterTests.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/ProtocolAdapterTests.java
@@ -31,6 +31,6 @@ public class ProtocolAdapterTests {
 			.severity(WARNING)
 			.build();
 		final Diagnostic actual = ProtocolAdapter.toDiagnostic(vEvent);
-		assertEquals("Ooops - should-show-up", actual.getMessage());
+		assertEquals("should-show-up: Ooops", actual.getMessage());
 	}
 }


### PR DESCRIPTION
Smithy support suppressing warnings via a metadata. To do
so, add a block like that before the namespace declaration in
your Smithy file:

```
metadata suppressions = [
    {
        id: "UnreferencedShape",
        namespace: "foo.baz",
        reason: "This is a test namespace."
    }
]
```

Right now, diagnostics in the LSP do not report the id of the
validator. It makes it harder for users to suppress a warning
they would like to be gone.

This PR adds the ID in the diagnostic message reported by the
LSP.

In the extension, it looks like this:
![Screen Shot 2022-03-30 at 09 49 01](https://user-images.githubusercontent.com/5230460/160853359-a409aa99-3a47-4da3-a773-f1b5e1242981.png)


