### PR TITLE
Temporary workaround to avoid NPE

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -9,7 +9,7 @@ object lsp extends MavenModule with PublishModule {
 
   def ivyDeps = Agg(
     ivy"org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0",
-    ivy"software.amazon.smithy:smithy-model:1.23.1",
+    ivy"software.amazon.smithy:smithy-model:1.25.0",
     ivy"io.get-coursier:interface:1.0.4"
   )
 

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -271,6 +271,9 @@ public final class SmithyProject {
     ) {
         for (Map.Entry<ShapeId, List<MemberShape>> entry : containerMembersMap.entrySet()) {
             Location containerLocation = locations.get(entry.getKey());
+            if (containerLocation == null) {
+                continue;
+            }
             Range containerLocationRange = containerLocation.getRange();
             int memberEndMarker = containerLocationRange.getEnd().getLine();
             // Keep track of previous line to make sure that end marker has been advanced.


### PR DESCRIPTION
Add a quick fix workaround to avoid an issue in the LSP. The upstream issue is still being resolved but this renders the IDE integration completely useless.