### PR TITLE
Show version on startup

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -130,4 +130,15 @@ object lsp extends MavenModule with PublishModule {
     s"$version$dirtySuffix"
   }
 
+  def writeVersion: T[PathRef] = T {
+    val version = publishVersion()
+    val targetDir = T.ctx().dest / "resources"
+
+    os.makeDir.all(targetDir)
+    os.write(targetDir / "version.properties", s"version=$version")
+    PathRef(targetDir)
+  }
+
+  override def localClasspath = super.localClasspath() :+ writeVersion()
+
 }


### PR DESCRIPTION
*Description of changes:*

Adds feature parity with the upstream by putting the server version into the `version.properties` resource in the Mill build. That way, it can be read at startup in the following part of the server init:

https://github.com/disneystreaming/smithy-language-server/blob/1bac60897567f10e1fdb698c3d4663de41f6629b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java#L143-L147

Demo:


https://github.com/disneystreaming/smithy-language-server/assets/894884/04d10129-8bd1-4ea1-b840-0ca1f5b3c709



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
