### PR TITLE
chore: fix direct smithy-build version

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -9,7 +9,7 @@ object lsp extends MavenModule with PublishModule {
 
   def ivyDeps = Agg(
     ivy"org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0",
-    ivy"software.amazon.smithy:smithy-model:1.35.0",
+    ivy"software.amazon.smithy:smithy-model:1.37.0",
     ivy"software.amazon.smithy:smithy-cli:1.37.0",
     ivy"io.get-coursier:interface:1.0.4",
     ivy"com.disneystreaming.smithy:smithytranslate-formatter-jvm-java-api:0.3.10"


### PR DESCRIPTION
Just bumping it in the direct dep. It was already being resolved to 1.37.0 because of transitive deps from `smithy-cli`, but these two numbers should be consistent, my bad.